### PR TITLE
Change Icon to supported one

### DIFF
--- a/custom_components/untappd/sensor.py
+++ b/custom_components/untappd/sensor.py
@@ -49,7 +49,7 @@ ATTR_DESCRIPTION = "description"
 
 SCAN_INTERVAL = timedelta(seconds=300)
 
-ICON = "mdi:untappd"
+ICON = "mdi:mdi-glass-mug-variant"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {


### PR DESCRIPTION
mdi:untappd will be removed from Home Assistant in 2021.12 as stated in the log. The easy fix is to use [mdi:mdi-glass-mug-variant](https://materialdesignicons.com/icon/glass-mug-variant) which still looks like beer.
Unfortunately there is no icon that looks like untappd any more.