### PR TITLE
Update deprecated usage of device_state_attributes.

### DIFF
--- a/custom_components/untappd/sensor.py
+++ b/custom_components/untappd/sensor.py
@@ -142,7 +142,7 @@ class UntappdCheckinSensor(Entity):
         return ICON
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             ATTR_ABV: self._abv,
             ATTR_BEER: self._beer,
@@ -215,7 +215,7 @@ class UntappdWishlistSensor(Entity):
         return ICON
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return self.hass.data[WISHLIST_DATA]
 
 
@@ -270,7 +270,7 @@ class UntappdLastBadgeSensor(Entity):
         return ICON
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             ATTR_BADGE: self._badge,
             ATTR_LEVEL: self._level,


### PR DESCRIPTION
Please see this change: https://github.com/home-assistant/developers.home-assistant/pull/837/files

'device_state_attributes' has  been renamed to 'extra_state_attributes'.

It was still working, but this was adding warnings to my log that I'm happy to address

Testing:

I installed the updated component, noticed all untappd sensors worked as expected, and noticed the warning no longer appears in my HA logs